### PR TITLE
.env file is in place for the demo

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PROXY_API_KEY=test-secret-key

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ wheels/
 .mypy_cache
 .DS_Store
 
-.env


### PR DESCRIPTION
Generally we gitignore an `.env` file for projects, hence why this was in place. But for our demo we actually depend on the PROXY_API_KEY being set, so it's fine to just commit it here.