### PR TITLE
sidecar: Include push ID in response

### DIFF
--- a/code-sync-mcp/src/code_sync_mcp/pb/ws_pb2.py
+++ b/code-sync-mcp/src/code_sync_mcp/pb/ws_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"a\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\"\xa3\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"a\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,11 +35,11 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_PUSHMESSAGE']._serialized_start=12
   _globals['_PUSHMESSAGE']._serialized_end=109
   _globals['_PUSHRESPONSE']._serialized_start=112
-  _globals['_PUSHRESPONSE']._serialized_end=275
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=193
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=275
-  _globals['_WEBSOCKETMESSAGE']._serialized_start=278
-  _globals['_WEBSOCKETMESSAGE']._serialized_end=503
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=429
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=492
+  _globals['_PUSHRESPONSE']._serialized_end=292
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=210
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=292
+  _globals['_WEBSOCKETMESSAGE']._serialized_start=295
+  _globals['_WEBSOCKETMESSAGE']._serialized_end=520
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=446
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=509
 # @@protoc_insertion_point(module_scope)

--- a/code-sync-proxy/src/code_sync_proxy/pb/ws_pb2.py
+++ b/code-sync-proxy/src/code_sync_proxy/pb/ws_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"a\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\"\xa3\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"a\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,11 +35,11 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_PUSHMESSAGE']._serialized_start=12
   _globals['_PUSHMESSAGE']._serialized_end=109
   _globals['_PUSHRESPONSE']._serialized_start=112
-  _globals['_PUSHRESPONSE']._serialized_end=275
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=193
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=275
-  _globals['_WEBSOCKETMESSAGE']._serialized_start=278
-  _globals['_WEBSOCKETMESSAGE']._serialized_end=503
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=429
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=492
+  _globals['_PUSHRESPONSE']._serialized_end=292
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=210
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=292
+  _globals['_WEBSOCKETMESSAGE']._serialized_start=295
+  _globals['_WEBSOCKETMESSAGE']._serialized_end=520
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=446
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=509
 # @@protoc_insertion_point(module_scope)

--- a/code-sync-sidecar/pb/ws.pb.go
+++ b/code-sync-sidecar/pb/ws.pb.go
@@ -197,6 +197,7 @@ type PushResponse struct {
 	state         protoimpl.MessageState  `protogen:"open.v1"`
 	Status        PushResponse_PushStatus `protobuf:"varint,1,opt,name=status,proto3,enum=PushResponse_PushStatus" json:"status,omitempty"`
 	ErrorMessage  string                  `protobuf:"bytes,2,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	PushId        string                  `protobuf:"bytes,3,opt,name=push_id,json=pushId,proto3" json:"push_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -241,6 +242,13 @@ func (x *PushResponse) GetStatus() PushResponse_PushStatus {
 func (x *PushResponse) GetErrorMessage() string {
 	if x != nil {
 		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *PushResponse) GetPushId() string {
+	if x != nil {
+		return x.PushId
 	}
 	return ""
 }
@@ -345,10 +353,11 @@ const file_ws_proto_rawDesc = "" +
 	"\n" +
 	"batch_file\x18\x02 \x01(\fR\tbatchFile\x12\x1b\n" +
 	"\tcode_diff\x18\x03 \x01(\tR\bcodeDiff\x12-\n" +
-	"\x12change_description\x18\x04 \x01(\tR\x11changeDescription\"\xb9\x01\n" +
+	"\x12change_description\x18\x04 \x01(\tR\x11changeDescription\"\xd2\x01\n" +
 	"\fPushResponse\x120\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x18.PushResponse.PushStatusR\x06status\x12#\n" +
-	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\"R\n" +
+	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12\x17\n" +
+	"\apush_id\x18\x03 \x01(\tR\x06pushId\"R\n" +
 	"\n" +
 	"PushStatus\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +

--- a/proto/ws.proto
+++ b/proto/ws.proto
@@ -19,6 +19,7 @@ message PushResponse {
 
     PushStatus status = 1;
     string error_message = 2;
+    string push_id = 3;
 }
 
 message WebsocketMessage {


### PR DESCRIPTION
Provides a way to match responses to their original requests. We will use this in some later changes to the websocket connection manager. But for now, this just provides the necessary plumbing for changes.