### PR TITLE
Env variable injection via PushMessage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ DIST_DIR := dist
 help:
 	@echo "Available commands:"
 	@echo "  sidecar-docker           - Build and push sidecar image to Docker"
+	@echo "  sidecar-local            - Build sidecar image locally for docker-compose"
 	@echo "  build-rsync-static       - Build static rsync binaries for amd64 and arm64"
 	@echo "  mcp-pypi-build          - Build Python package for PyPI"
 	@echo "  mcp-pypi-test           - Upload package to TestPyPI"
@@ -63,6 +64,11 @@ sidecar-docker: build-rsync-static setup-buildx
 	$(eval IMG := $(DOCKER_IMAGE):$(IMAGE_TAG)) # Using generic IMAGE_TAG
 	docker buildx build --no-cache -f code-sync-sidecar/Dockerfile --platform $(SUPPORTED_PLATFORMS) -t $(IMG) --push .
 	@echo "Sidecar image successfully pushed to $(IMG)"
+
+sidecar-local: build-rsync-static-amd64
+	@echo "Building sidecar image for local use (linux/amd64 platform)..."
+	docker build --no-cache --platform linux/amd64 -f code-sync-sidecar/Dockerfile -t $(DOCKER_IMAGE):$(IMAGE_TAG) .
+	@echo "Sidecar image built locally as $(DOCKER_IMAGE):$(IMAGE_TAG)"
 
 # MCP Server PyPI related commands
 mcp-pypi-clean:

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,15 @@ DIST_DIR := dist
 
 help:
 	@echo "Available commands:"
-	@echo "  sidecar-docker           - Build and push sidecar image to Docker"
-	@echo "  sidecar-local            - Build sidecar image locally for docker-compose"
-	@echo "  build-rsync-static       - Build static rsync binaries for amd64 and arm64"
-	@echo "  mcp-pypi-build          - Build Python package for PyPI"
-	@echo "  mcp-pypi-test           - Upload package to TestPyPI"
-	@echo "  mcp-pypi-publish        - Upload package to production PyPI"
-	@echo "  mcp-pypi-clean          - Clean build artifacts"
-	@echo "  mcp-pypi-install-test   - Install package from TestPyPI"
+	@echo "  sidecar-docker         - Build and push sidecar image to Docker"
+	@echo "  sidecar-local          - Build sidecar image locally for docker-compose"
+	@echo "  build-rsync-static     - Build static rsync binaries for amd64 and arm64"
+	@echo "  mcp-pypi-build         - Build Python package for PyPI"
+	@echo "  mcp-pypi-test          - Upload package to TestPyPI"
+	@echo "  mcp-pypi-publish       - Upload package to production PyPI"
+	@echo "  mcp-pypi-clean         - Clean build artifacts"
+	@echo "  mcp-pypi-install-test  - Install package from TestPyPI"
+	@echo "  proto                  - Generate protobuf files"
 
 setup-buildx:
 	@if ! docker buildx ls | grep -q "$(BUILDX_BUILDER)"; then \

--- a/code-sync-mcp/src/code_sync_mcp/pb/ws_pb2.py
+++ b/code-sync-mcp/src/code_sync_mcp/pb/ws_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"a\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"\xe5\x01\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\x12\x45\n\x15\x65nvironment_variables\x18\x05 \x03(\x0b\x32&.PushMessage.EnvironmentVariablesEntry\x1a;\n\x19\x45nvironmentVariablesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,14 +32,18 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'ws_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pb'
-  _globals['_PUSHMESSAGE']._serialized_start=12
-  _globals['_PUSHMESSAGE']._serialized_end=109
-  _globals['_PUSHRESPONSE']._serialized_start=112
-  _globals['_PUSHRESPONSE']._serialized_end=292
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=210
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=292
-  _globals['_WEBSOCKETMESSAGE']._serialized_start=295
-  _globals['_WEBSOCKETMESSAGE']._serialized_end=520
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=446
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=509
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._loaded_options = None
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_options = b'8\001'
+  _globals['_PUSHMESSAGE']._serialized_start=13
+  _globals['_PUSHMESSAGE']._serialized_end=242
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_start=183
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_end=242
+  _globals['_PUSHRESPONSE']._serialized_start=245
+  _globals['_PUSHRESPONSE']._serialized_end=425
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=343
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=425
+  _globals['_WEBSOCKETMESSAGE']._serialized_start=428
+  _globals['_WEBSOCKETMESSAGE']._serialized_end=653
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=579
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=642
 # @@protoc_insertion_point(module_scope)

--- a/code-sync-mcp/src/code_sync_mcp/pb/ws_pb2.py
+++ b/code-sync-mcp/src/code_sync_mcp/pb/ws_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"\xe5\x01\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\x12\x45\n\x15\x65nvironment_variables\x18\x05 \x03(\x0b\x32&.PushMessage.EnvironmentVariablesEntry\x1a;\n\x19\x45nvironmentVariablesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"\xa2\x02\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\x12\x15\n\rfiles_changed\x18\x05 \x01(\x05\x12\x11\n\tadditions\x18\x06 \x01(\x05\x12\x11\n\tdeletions\x18\x07 \x01(\x05\x12\x45\n\x15\x65nvironment_variables\x18\x08 \x03(\x0b\x32&.PushMessage.EnvironmentVariablesEntry\x1a;\n\x19\x45nvironmentVariablesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,15 +35,15 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._loaded_options = None
   _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_options = b'8\001'
   _globals['_PUSHMESSAGE']._serialized_start=13
-  _globals['_PUSHMESSAGE']._serialized_end=242
-  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_start=183
-  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_end=242
-  _globals['_PUSHRESPONSE']._serialized_start=245
-  _globals['_PUSHRESPONSE']._serialized_end=425
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=343
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=425
-  _globals['_WEBSOCKETMESSAGE']._serialized_start=428
-  _globals['_WEBSOCKETMESSAGE']._serialized_end=653
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=579
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=642
+  _globals['_PUSHMESSAGE']._serialized_end=303
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_start=244
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_end=303
+  _globals['_PUSHRESPONSE']._serialized_start=306
+  _globals['_PUSHRESPONSE']._serialized_end=486
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=404
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=486
+  _globals['_WEBSOCKETMESSAGE']._serialized_start=489
+  _globals['_WEBSOCKETMESSAGE']._serialized_end=714
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=640
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=703
 # @@protoc_insertion_point(module_scope)

--- a/code-sync-proxy/src/code_sync_proxy/pb/ws_pb2.py
+++ b/code-sync-proxy/src/code_sync_proxy/pb/ws_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"a\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"\xe5\x01\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\x12\x45\n\x15\x65nvironment_variables\x18\x05 \x03(\x0b\x32&.PushMessage.EnvironmentVariablesEntry\x1a;\n\x19\x45nvironmentVariablesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,14 +32,18 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'ws_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pb'
-  _globals['_PUSHMESSAGE']._serialized_start=12
-  _globals['_PUSHMESSAGE']._serialized_end=109
-  _globals['_PUSHRESPONSE']._serialized_start=112
-  _globals['_PUSHRESPONSE']._serialized_end=292
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=210
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=292
-  _globals['_WEBSOCKETMESSAGE']._serialized_start=295
-  _globals['_WEBSOCKETMESSAGE']._serialized_end=520
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=446
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=509
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._loaded_options = None
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_options = b'8\001'
+  _globals['_PUSHMESSAGE']._serialized_start=13
+  _globals['_PUSHMESSAGE']._serialized_end=242
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_start=183
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_end=242
+  _globals['_PUSHRESPONSE']._serialized_start=245
+  _globals['_PUSHRESPONSE']._serialized_end=425
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=343
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=425
+  _globals['_WEBSOCKETMESSAGE']._serialized_start=428
+  _globals['_WEBSOCKETMESSAGE']._serialized_end=653
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=579
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=642
 # @@protoc_insertion_point(module_scope)

--- a/code-sync-proxy/src/code_sync_proxy/pb/ws_pb2.py
+++ b/code-sync-proxy/src/code_sync_proxy/pb/ws_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"\xe5\x01\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\x12\x45\n\x15\x65nvironment_variables\x18\x05 \x03(\x0b\x32&.PushMessage.EnvironmentVariablesEntry\x1a;\n\x19\x45nvironmentVariablesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x08ws.proto\"\xa2\x02\n\x0bPushMessage\x12\x0f\n\x07push_id\x18\x01 \x01(\t\x12\x12\n\nbatch_file\x18\x02 \x01(\x0c\x12\x11\n\tcode_diff\x18\x03 \x01(\t\x12\x1a\n\x12\x63hange_description\x18\x04 \x01(\t\x12\x15\n\rfiles_changed\x18\x05 \x01(\x05\x12\x11\n\tadditions\x18\x06 \x01(\x05\x12\x11\n\tdeletions\x18\x07 \x01(\x05\x12\x45\n\x15\x65nvironment_variables\x18\x08 \x03(\x0b\x32&.PushMessage.EnvironmentVariablesEntry\x1a;\n\x19\x45nvironmentVariablesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb4\x01\n\x0cPushResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.PushResponse.PushStatus\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07push_id\x18\x03 \x01(\t\"R\n\nPushStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0f\n\x0bIN_PROGRESS\x10\x02\x12\n\n\x06\x46\x41ILED\x10\x03\x12\r\n\tCOMPLETED\x10\x04\"\xe1\x01\n\x10WebsocketMessage\x12\x33\n\x0cmessage_type\x18\x01 \x01(\x0e\x32\x1d.WebsocketMessage.MessageType\x12$\n\x0cpush_message\x18\x02 \x01(\x0b\x32\x0c.PushMessageH\x00\x12&\n\rpush_response\x18\x03 \x01(\x0b\x32\r.PushResponseH\x00\"?\n\x0bMessageType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0cPUSH_REQUEST\x10\x01\x12\x11\n\rPUSH_RESPONSE\x10\x02\x42\t\n\x07messageB:Z8github.com/bifrostinc/code-sync-mcp/code-sync-sidecar/pbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,15 +35,15 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._loaded_options = None
   _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_options = b'8\001'
   _globals['_PUSHMESSAGE']._serialized_start=13
-  _globals['_PUSHMESSAGE']._serialized_end=242
-  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_start=183
-  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_end=242
-  _globals['_PUSHRESPONSE']._serialized_start=245
-  _globals['_PUSHRESPONSE']._serialized_end=425
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=343
-  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=425
-  _globals['_WEBSOCKETMESSAGE']._serialized_start=428
-  _globals['_WEBSOCKETMESSAGE']._serialized_end=653
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=579
-  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=642
+  _globals['_PUSHMESSAGE']._serialized_end=303
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_start=244
+  _globals['_PUSHMESSAGE_ENVIRONMENTVARIABLESENTRY']._serialized_end=303
+  _globals['_PUSHRESPONSE']._serialized_start=306
+  _globals['_PUSHRESPONSE']._serialized_end=486
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_start=404
+  _globals['_PUSHRESPONSE_PUSHSTATUS']._serialized_end=486
+  _globals['_WEBSOCKETMESSAGE']._serialized_start=489
+  _globals['_WEBSOCKETMESSAGE']._serialized_end=714
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_start=640
+  _globals['_WEBSOCKETMESSAGE_MESSAGETYPE']._serialized_end=703
 # @@protoc_insertion_point(module_scope)

--- a/code-sync-sidecar/env_manager.go
+++ b/code-sync-sidecar/env_manager.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/bifrostinc/code-sync-sidecar/log"
+)
+
+// EnvironmentManager manages environment variables from push messages,
+// syncing them to a .env file for use by the launcher script.
+type EnvironmentManager struct {
+	envFilePath string
+}
+
+// NewEnvironmentManager creates a new environment manager that will write
+// environment variables to the specified directory.
+func NewEnvironmentManager(targetSyncDir string) *EnvironmentManager {
+	sidecarDir := getSidecarDir(targetSyncDir)
+	envFilePath := filepath.Join(sidecarDir, ".env")
+	
+	return &EnvironmentManager{
+		envFilePath: envFilePath,
+	}
+}
+
+// UpdateFromPush updates the environment variables from a push message.
+// This acts as a PUT operation - it completely replaces all environment variables
+// with the ones provided in the push message.
+func (em *EnvironmentManager) UpdateFromPush(envVariables map[string]string) error {
+	if envVariables == nil {
+		envVariables = make(map[string]string)
+	}
+
+	log.Info("Updating environment variables from push", 
+		zap.Int("numVariables", len(envVariables)),
+		zap.String("envFilePath", em.envFilePath))
+
+	// Ensure the sidecar directory exists
+	if err := os.MkdirAll(filepath.Dir(em.envFilePath), 0777); err != nil {
+		return fmt.Errorf("failed to create sidecar directory: %w", err)
+	}
+
+	// Build the .env file content
+	var lines []string
+	
+	// Sort keys for consistent output and easier testing
+	var keys []string
+	for key := range envVariables {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := envVariables[key]
+		// Escape values that contain special characters by wrapping in quotes
+		escapedValue := escapeEnvValue(value)
+		line := fmt.Sprintf("export %s=%s", key, escapedValue)
+		lines = append(lines, line)
+	}
+
+	content := strings.Join(lines, "\n")
+	if len(lines) > 0 {
+		content += "\n" // Add trailing newline
+	}
+
+	// Write the .env file atomically using a temporary file
+	tempFile := em.envFilePath + ".tmp"
+	if err := os.WriteFile(tempFile, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write temporary env file: %w", err)
+	}
+
+	if err := os.Rename(tempFile, em.envFilePath); err != nil {
+		os.Remove(tempFile) // Clean up on failure
+		return fmt.Errorf("failed to replace env file: %w", err)
+	}
+
+	log.Info("Successfully updated environment file", 
+		zap.String("path", em.envFilePath),
+		zap.Int("variables", len(envVariables)))
+
+	return nil
+}
+
+// GetEnvFilePath returns the path to the .env file.
+func (em *EnvironmentManager) GetEnvFilePath() string {
+	return em.envFilePath
+}
+
+// escapeEnvValue escapes environment variable values for shell consumption.
+// It wraps values in single quotes if they contain special characters.
+func escapeEnvValue(value string) string {
+	// If the value is empty, return empty quotes
+	if value == "" {
+		return "''"
+	}
+
+	// Check if the value needs escaping (contains spaces, quotes, or special chars)
+	needsEscaping := false
+	for _, char := range value {
+		if char == ' ' || char == '\t' || char == '\n' || char == '\r' || 
+		   char == '"' || char == '\'' || char == '\\' || char == '$' ||
+		   char == '`' || char == '|' || char == '&' || char == ';' ||
+		   char == '(' || char == ')' || char == '<' || char == '>' {
+			needsEscaping = true
+			break
+		}
+	}
+
+	if !needsEscaping {
+		return value
+	}
+
+	// Use single quotes and escape any single quotes in the value
+	escaped := strings.ReplaceAll(value, "'", "'\"'\"'")
+	return "'" + escaped + "'"
+}

--- a/code-sync-sidecar/env_manager.go
+++ b/code-sync-sidecar/env_manager.go
@@ -23,7 +23,7 @@ type EnvironmentManager struct {
 func NewEnvironmentManager(targetSyncDir string) *EnvironmentManager {
 	sidecarDir := getSidecarDir(targetSyncDir)
 	envFilePath := filepath.Join(sidecarDir, ".env")
-	
+
 	return &EnvironmentManager{
 		envFilePath: envFilePath,
 	}
@@ -37,7 +37,7 @@ func (em *EnvironmentManager) UpdateFromPush(envVariables map[string]string) err
 		envVariables = make(map[string]string)
 	}
 
-	log.Info("Updating environment variables from push", 
+	log.Info("Updating environment variables from push",
 		zap.Int("numVariables", len(envVariables)),
 		zap.String("envFilePath", em.envFilePath))
 
@@ -46,10 +46,8 @@ func (em *EnvironmentManager) UpdateFromPush(envVariables map[string]string) err
 		return fmt.Errorf("failed to create sidecar directory: %w", err)
 	}
 
-	// Build the .env file content
-	var lines []string
-	
 	// Sort keys for consistent output and easier testing
+	var lines []string
 	var keys []string
 	for key := range envVariables {
 		keys = append(keys, key)
@@ -66,21 +64,20 @@ func (em *EnvironmentManager) UpdateFromPush(envVariables map[string]string) err
 
 	content := strings.Join(lines, "\n")
 	if len(lines) > 0 {
-		content += "\n" // Add trailing newline
+		content += "\n"
 	}
 
-	// Write the .env file atomically using a temporary file
 	tempFile := em.envFilePath + ".tmp"
 	if err := os.WriteFile(tempFile, []byte(content), 0644); err != nil {
 		return fmt.Errorf("failed to write temporary env file: %w", err)
 	}
 
 	if err := os.Rename(tempFile, em.envFilePath); err != nil {
-		os.Remove(tempFile) // Clean up on failure
+		os.Remove(tempFile)
 		return fmt.Errorf("failed to replace env file: %w", err)
 	}
 
-	log.Info("Successfully updated environment file", 
+	log.Info("Successfully updated environment file",
 		zap.String("path", em.envFilePath),
 		zap.Int("variables", len(envVariables)))
 
@@ -103,10 +100,10 @@ func escapeEnvValue(value string) string {
 	// Check if the value needs escaping (contains spaces, quotes, or special chars)
 	needsEscaping := false
 	for _, char := range value {
-		if char == ' ' || char == '\t' || char == '\n' || char == '\r' || 
-		   char == '"' || char == '\'' || char == '\\' || char == '$' ||
-		   char == '`' || char == '|' || char == '&' || char == ';' ||
-		   char == '(' || char == ')' || char == '<' || char == '>' {
+		if char == ' ' || char == '\t' || char == '\n' || char == '\r' ||
+			char == '"' || char == '\'' || char == '\\' || char == '$' ||
+			char == '`' || char == '|' || char == '&' || char == ';' ||
+			char == '(' || char == ')' || char == '<' || char == '>' {
 			needsEscaping = true
 			break
 		}

--- a/code-sync-sidecar/env_manager_test.go
+++ b/code-sync-sidecar/env_manager_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEnvironmentManager(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "env_manager_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	em := NewEnvironmentManager(tmpDir)
+	require.NotNil(t, em)
+
+	expectedPath := filepath.Join(getSidecarDir(tmpDir), ".env")
+	assert.Equal(t, expectedPath, em.GetEnvFilePath())
+}
+
+func TestEnvironmentManager_UpdateFromPush(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "env_manager_update_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	em := NewEnvironmentManager(tmpDir)
+
+	tests := []struct {
+		name           string
+		envVars        map[string]string
+		expectedLines  []string
+		expectedError  bool
+	}{
+		{
+			name:    "nil environment variables",
+			envVars: nil,
+			expectedLines: []string{},
+			expectedError: false,
+		},
+		{
+			name:    "empty environment variables",
+			envVars: map[string]string{},
+			expectedLines: []string{},
+			expectedError: false,
+		},
+		{
+			name: "simple environment variables",
+			envVars: map[string]string{
+				"API_KEY": "secret123",
+				"DB_URL":  "postgres://localhost/test",
+			},
+			expectedLines: []string{
+				"export API_KEY=secret123",
+				"export DB_URL=postgres://localhost/test",
+			},
+			expectedError: false,
+		},
+		{
+			name: "environment variables with special characters",
+			envVars: map[string]string{
+				"COMPLEX_VAR": "value with spaces",
+				"QUOTED_VAR":  "value'with'quotes",
+				"DOLLAR_VAR":  "value$with$dollars",
+			},
+			expectedLines: []string{
+				"export COMPLEX_VAR='value with spaces'",
+				"export QUOTED_VAR='value'\"'\"'with'\"'\"'quotes'",
+				"export DOLLAR_VAR='value$with$dollars'",
+			},
+			expectedError: false,
+		},
+		{
+			name: "empty value",
+			envVars: map[string]string{
+				"EMPTY_VAR": "",
+			},
+			expectedLines: []string{
+				"export EMPTY_VAR=''",
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := em.UpdateFromPush(tt.envVars)
+			
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+			
+			require.NoError(t, err)
+
+			// Read the generated file
+			content, err := os.ReadFile(em.GetEnvFilePath())
+			require.NoError(t, err)
+
+			contentStr := string(content)
+			lines := strings.Split(strings.TrimSpace(contentStr), "\n")
+			
+			// If no environment variables, file should be empty
+			if len(tt.envVars) == 0 {
+				assert.Empty(t, strings.TrimSpace(contentStr), "File should be empty for no env vars")
+				return
+			}
+
+			// Filter out empty lines
+			var actualLines []string
+			for _, line := range lines {
+				if strings.TrimSpace(line) != "" {
+					actualLines = append(actualLines, line)
+				}
+			}
+
+			assert.Len(t, actualLines, len(tt.expectedLines), "Number of lines should match")
+			
+			// Check that all expected lines are present (order might vary due to map iteration)
+			for _, expectedLine := range tt.expectedLines {
+				found := false
+				for _, actualLine := range actualLines {
+					if actualLine == expectedLine {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Expected line '%s' not found in output: %v", expectedLine, actualLines)
+			}
+
+			// Verify file ends with newline if there are variables
+			if len(tt.envVars) > 0 {
+				assert.True(t, strings.HasSuffix(contentStr, "\n"), "File should end with newline")
+			}
+		})
+	}
+}
+
+func TestEnvironmentManager_UpdateFromPush_Atomic(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "env_manager_atomic_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	em := NewEnvironmentManager(tmpDir)
+
+	// First update
+	envVars1 := map[string]string{
+		"VAR1": "value1",
+		"VAR2": "value2",
+	}
+	err = em.UpdateFromPush(envVars1)
+	require.NoError(t, err)
+
+	// Verify first update
+	content, err := os.ReadFile(em.GetEnvFilePath())
+	require.NoError(t, err)
+	contentStr := string(content)
+	assert.Contains(t, contentStr, "export VAR1=value1")
+	assert.Contains(t, contentStr, "export VAR2=value2")
+
+	// Second update - should completely replace
+	envVars2 := map[string]string{
+		"VAR3": "value3",
+	}
+	err = em.UpdateFromPush(envVars2)
+	require.NoError(t, err)
+
+	// Verify second update completely replaced the first
+	content, err = os.ReadFile(em.GetEnvFilePath())
+	require.NoError(t, err)
+	contentStr = string(content)
+	assert.Contains(t, contentStr, "export VAR3=value3")
+	assert.NotContains(t, contentStr, "VAR1", "Old variables should be removed")
+	assert.NotContains(t, contentStr, "VAR2", "Old variables should be removed")
+}
+
+func TestEscapeEnvValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple value",
+			input:    "simple",
+			expected: "simple",
+		},
+		{
+			name:     "empty value",
+			input:    "",
+			expected: "''",
+		},
+		{
+			name:     "value with spaces",
+			input:    "value with spaces",
+			expected: "'value with spaces'",
+		},
+		{
+			name:     "value with single quotes",
+			input:    "value'with'quotes",
+			expected: "'value'\"'\"'with'\"'\"'quotes'",
+		},
+		{
+			name:     "value with double quotes",
+			input:    "value\"with\"quotes",
+			expected: "'value\"with\"quotes'",
+		},
+		{
+			name:     "value with dollar signs",
+			input:    "value$with$dollars",
+			expected: "'value$with$dollars'",
+		},
+		{
+			name:     "value with backslashes",
+			input:    "value\\with\\backslashes",
+			expected: "'value\\with\\backslashes'",
+		},
+		{
+			name:     "value with backticks",
+			input:    "value`with`backticks",
+			expected: "'value`with`backticks'",
+		},
+		{
+			name:     "value with special shell characters",
+			input:    "value|with&special;chars",
+			expected: "'value|with&special;chars'",
+		},
+		{
+			name:     "value with parentheses",
+			input:    "value(with)parens",
+			expected: "'value(with)parens'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := escapeEnvValue(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEnvironmentManager_DirectoryCreation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "env_manager_dir_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Use a subdirectory that doesn't exist yet
+	targetDir := filepath.Join(tmpDir, "non-existent", "nested")
+	em := NewEnvironmentManager(targetDir)
+
+	envVars := map[string]string{
+		"TEST_VAR": "test_value",
+	}
+
+	err = em.UpdateFromPush(envVars)
+	require.NoError(t, err)
+
+	// Verify the directories were created
+	sidecarDir := getSidecarDir(targetDir)
+	assert.DirExists(t, sidecarDir, "Sidecar directory should be created")
+
+	// Verify the file was created with correct content
+	content, err := os.ReadFile(em.GetEnvFilePath())
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "export TEST_VAR=test_value")
+}

--- a/code-sync-sidecar/file_syncer.go
+++ b/code-sync-sidecar/file_syncer.go
@@ -224,9 +224,11 @@ func (rw *FileSyncer) handlePushRequest(pushMsg *pb.PushMessage) error {
 	batchData := pushMsg.BatchFile
 	envVariables := pushMsg.EnvironmentVariables
 
-	log.Info("Processing push request", 
+	log.Info("Processing push request",
 		zap.String("pushID", pushID),
+		zap.Bool("hasBatchData", len(batchData) > 0),
 		zap.Int("batchSize", len(batchData)),
+		zap.Bool("hasEnvVars", len(envVariables) > 0),
 		zap.Int("envVars", len(envVariables)))
 
 	// Update environment variables first (always do this, even if no batch data)

--- a/code-sync-sidecar/file_syncer_test.go
+++ b/code-sync-sidecar/file_syncer_test.go
@@ -336,8 +336,8 @@ func TestApplyPushMessage(t *testing.T) {
 			name:           "empty batch data with env vars",
 			batchData:      []byte{},
 			envVars:        map[string]string{"TEST_VAR": "test_value", "DB_URL": "postgres://localhost/test"},
-			expectSignal:   true,  // Signal sent even for env-only updates
-			expectResponse: true,  // Message sent for successful env update
+			expectSignal:   true, // Signal sent even for env-only updates
+			expectResponse: true, // Message sent for successful env update
 			expectedErr:    "",
 		},
 		{
@@ -436,8 +436,8 @@ func TestApplyPushMessage(t *testing.T) {
 
 			// Run the function under test
 			err := rw.handlePushRequest(&pb.PushMessage{
-				PushId: pushID, 
-				BatchFile: tt.batchData,
+				PushId:               pushID,
+				BatchFile:            tt.batchData,
 				EnvironmentVariables: tt.envVars,
 			})
 
@@ -502,7 +502,7 @@ func TestApplyPushMessage(t *testing.T) {
 				envFilePath := rw.envManager.GetEnvFilePath()
 				envContent, err := os.ReadFile(envFilePath)
 				require.NoError(t, err, "Should be able to read environment file")
-				
+
 				envStr := string(envContent)
 				for key, value := range tt.envVars {
 					expectedLine := fmt.Sprintf("export %s=%s", key, value)

--- a/code-sync-sidecar/launcher-script/rsync-launcher.sh
+++ b/code-sync-sidecar/launcher-script/rsync-launcher.sh
@@ -122,6 +122,15 @@ start_app() {
         unset BIFROST_PUSH_ID
     fi
 
+    # Source database environment variables if they exist
+    DATABASE_ENV_FILE="${SIDECAR_DIR}/env.sh"
+    if [ -f "$DATABASE_ENV_FILE" ]; then
+        echo "[code-sync] Sourcing database environment variables from $DATABASE_ENV_FILE"
+        . "$DATABASE_ENV_FILE"
+    else
+        echo "[code-sync] No database environment file found at $DATABASE_ENV_FILE"
+    fi
+
     # Kill previous instance if it exists
     if [ -f "$APP_PID_FILE" ]; then
         old_pid=$(cat "$APP_PID_FILE")

--- a/code-sync-sidecar/launcher-script/rsync-launcher.sh
+++ b/code-sync-sidecar/launcher-script/rsync-launcher.sh
@@ -122,13 +122,13 @@ start_app() {
         unset BIFROST_PUSH_ID
     fi
 
-    # Source database environment variables if they exist
-    DATABASE_ENV_FILE="${SIDECAR_DIR}/env.sh"
-    if [ -f "$DATABASE_ENV_FILE" ]; then
-        echo "[code-sync] Sourcing database environment variables from $DATABASE_ENV_FILE"
-        . "$DATABASE_ENV_FILE"
+    # Source environment variables if they exist
+    ENV_FILE="${SIDECAR_DIR}/.env"
+    if [ -f "$ENV_FILE" ]; then
+        echo "[code-sync] Sourcing environment variables from $ENV_FILE"
+        . "$ENV_FILE"
     else
-        echo "[code-sync] No database environment file found at $DATABASE_ENV_FILE"
+        echo "[code-sync] No environment file found at $ENV_FILE"
     fi
 
     # Kill previous instance if it exists

--- a/code-sync-sidecar/main.go
+++ b/code-sync-sidecar/main.go
@@ -80,7 +80,6 @@ func main() {
 		log.Fatal("Failed to copy binaries", zap.Error(err))
 	}
 
-
 	// Create a context that will be canceled on SIGTERM/SIGINT
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -181,4 +180,3 @@ func copyBinaries(filesDir string) error {
 	log.Info("Successfully set up binaries", zap.String("targetDir", filesDir))
 	return nil
 }
-

--- a/code-sync-sidecar/main.go
+++ b/code-sync-sidecar/main.go
@@ -2,16 +2,13 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	stdlog "log"
-	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -83,11 +80,6 @@ func main() {
 		log.Fatal("Failed to copy binaries", zap.Error(err))
 	}
 
-	// Fetch and write database environment variables
-	if err := writeDatabaseEnvFile(apiURL, apiKey, deploymentID, filesDir); err != nil {
-		log.Warn("Failed to write database environment file", zap.Error(err))
-		// Don't fail - let the app start without database URLs
-	}
 
 	// Create a context that will be canceled on SIGTERM/SIGINT
 	ctx, cancel := context.WithCancel(context.Background())
@@ -190,84 +182,3 @@ func copyBinaries(filesDir string) error {
 	return nil
 }
 
-// DatabaseEnvVar represents a database environment variable
-type DatabaseEnvVar struct {
-	EnvVarName     string `json:"env_var_name"`
-	ConnectionURI  string `json:"connection_uri"`
-}
-
-// writeDatabaseEnvFile fetches database connection URIs from the API and writes them to an env file
-func writeDatabaseEnvFile(apiURL, apiKey, deploymentID, filesDir string) error {
-	log.Info("Fetching database environment variables", 
-		zap.String("deploymentID", deploymentID),
-		zap.String("apiURL", apiURL))
-
-	// Build the API endpoint URL
-	url := fmt.Sprintf("%s/api/v1/deployments/%s/database-env-vars", apiURL, deploymentID)
-	
-	// Create HTTP client with timeout
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	
-	// Create request with API key header
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("X-Api-Key", apiKey)
-	
-	// Make the request
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to fetch database env vars: %w", err)
-	}
-	defer resp.Body.Close()
-	
-	// Check response status
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-	
-	// Parse response
-	var envVars []DatabaseEnvVar
-	if err := json.NewDecoder(resp.Body).Decode(&envVars); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
-	}
-	
-	// If no databases, don't create the file
-	if len(envVars) == 0 {
-		log.Info("No database environment variables to inject")
-		return nil
-	}
-	
-	// Write to env.sh file
-	envFile := filepath.Join(getSidecarDir(filesDir), "env.sh")
-	f, err := os.Create(envFile)
-	if err != nil {
-		return fmt.Errorf("failed to create env file: %w", err)
-	}
-	defer f.Close()
-	
-	// Write each environment variable
-	for _, envVar := range envVars {
-		if _, err := fmt.Fprintf(f, "export %s=\"%s\"\n", envVar.EnvVarName, envVar.ConnectionURI); err != nil {
-			return fmt.Errorf("failed to write env var %s: %w", envVar.EnvVarName, err)
-		}
-		log.Info("Added database environment variable", 
-			zap.String("envVar", envVar.EnvVarName),
-			zap.String("envFile", envFile))
-	}
-	
-	// Make file readable by all
-	if err := os.Chmod(envFile, 0644); err != nil {
-		log.Warn("Failed to set env file permissions", zap.Error(err))
-	}
-	
-	log.Info("Successfully wrote database environment variables", 
-		zap.String("envFile", envFile),
-		zap.Int("count", len(envVars)))
-	
-	return nil
-}

--- a/code-sync-sidecar/pb/ws.pb.go
+++ b/code-sync-sidecar/pb/ws.pb.go
@@ -126,12 +126,16 @@ func (WebsocketMessage_MessageType) EnumDescriptor() ([]byte, []int) {
 }
 
 type PushMessage struct {
-	state                protoimpl.MessageState `protogen:"open.v1"`
-	PushId               string                 `protobuf:"bytes,1,opt,name=push_id,json=pushId,proto3" json:"push_id,omitempty"`
-	BatchFile            []byte                 `protobuf:"bytes,2,opt,name=batch_file,json=batchFile,proto3" json:"batch_file,omitempty"`
-	CodeDiff             string                 `protobuf:"bytes,3,opt,name=code_diff,json=codeDiff,proto3" json:"code_diff,omitempty"`
-	ChangeDescription    string                 `protobuf:"bytes,4,opt,name=change_description,json=changeDescription,proto3" json:"change_description,omitempty"`
-	EnvironmentVariables map[string]string      `protobuf:"bytes,5,rep,name=environment_variables,json=environmentVariables,proto3" json:"environment_variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	PushId            string                 `protobuf:"bytes,1,opt,name=push_id,json=pushId,proto3" json:"push_id,omitempty"`
+	BatchFile         []byte                 `protobuf:"bytes,2,opt,name=batch_file,json=batchFile,proto3" json:"batch_file,omitempty"`
+	CodeDiff          string                 `protobuf:"bytes,3,opt,name=code_diff,json=codeDiff,proto3" json:"code_diff,omitempty"`
+	ChangeDescription string                 `protobuf:"bytes,4,opt,name=change_description,json=changeDescription,proto3" json:"change_description,omitempty"`
+	// Diff metadata fields (merged from DiffMetadata)
+	FilesChanged         int32             `protobuf:"varint,5,opt,name=files_changed,json=filesChanged,proto3" json:"files_changed,omitempty"`
+	Additions            int32             `protobuf:"varint,6,opt,name=additions,proto3" json:"additions,omitempty"`
+	Deletions            int32             `protobuf:"varint,7,opt,name=deletions,proto3" json:"deletions,omitempty"`
+	EnvironmentVariables map[string]string `protobuf:"bytes,8,rep,name=environment_variables,json=environmentVariables,proto3" json:"environment_variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -192,6 +196,27 @@ func (x *PushMessage) GetChangeDescription() string {
 		return x.ChangeDescription
 	}
 	return ""
+}
+
+func (x *PushMessage) GetFilesChanged() int32 {
+	if x != nil {
+		return x.FilesChanged
+	}
+	return 0
+}
+
+func (x *PushMessage) GetAdditions() int32 {
+	if x != nil {
+		return x.Additions
+	}
+	return 0
+}
+
+func (x *PushMessage) GetDeletions() int32 {
+	if x != nil {
+		return x.Deletions
+	}
+	return 0
 }
 
 func (x *PushMessage) GetEnvironmentVariables() map[string]string {
@@ -355,14 +380,17 @@ var File_ws_proto protoreflect.FileDescriptor
 
 const file_ws_proto_rawDesc = "" +
 	"\n" +
-	"\bws.proto\"\xb7\x02\n" +
+	"\bws.proto\"\x98\x03\n" +
 	"\vPushMessage\x12\x17\n" +
 	"\apush_id\x18\x01 \x01(\tR\x06pushId\x12\x1d\n" +
 	"\n" +
 	"batch_file\x18\x02 \x01(\fR\tbatchFile\x12\x1b\n" +
 	"\tcode_diff\x18\x03 \x01(\tR\bcodeDiff\x12-\n" +
-	"\x12change_description\x18\x04 \x01(\tR\x11changeDescription\x12[\n" +
-	"\x15environment_variables\x18\x05 \x03(\v2&.PushMessage.EnvironmentVariablesEntryR\x14environmentVariables\x1aG\n" +
+	"\x12change_description\x18\x04 \x01(\tR\x11changeDescription\x12#\n" +
+	"\rfiles_changed\x18\x05 \x01(\x05R\ffilesChanged\x12\x1c\n" +
+	"\tadditions\x18\x06 \x01(\x05R\tadditions\x12\x1c\n" +
+	"\tdeletions\x18\a \x01(\x05R\tdeletions\x12[\n" +
+	"\x15environment_variables\x18\b \x03(\v2&.PushMessage.EnvironmentVariablesEntryR\x14environmentVariables\x1aG\n" +
 	"\x19EnvironmentVariablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xd2\x01\n" +

--- a/code-sync-sidecar/pb/ws.pb.go
+++ b/code-sync-sidecar/pb/ws.pb.go
@@ -126,13 +126,14 @@ func (WebsocketMessage_MessageType) EnumDescriptor() ([]byte, []int) {
 }
 
 type PushMessage struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	PushId            string                 `protobuf:"bytes,1,opt,name=push_id,json=pushId,proto3" json:"push_id,omitempty"`
-	BatchFile         []byte                 `protobuf:"bytes,2,opt,name=batch_file,json=batchFile,proto3" json:"batch_file,omitempty"`
-	CodeDiff          string                 `protobuf:"bytes,3,opt,name=code_diff,json=codeDiff,proto3" json:"code_diff,omitempty"`
-	ChangeDescription string                 `protobuf:"bytes,4,opt,name=change_description,json=changeDescription,proto3" json:"change_description,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	PushId               string                 `protobuf:"bytes,1,opt,name=push_id,json=pushId,proto3" json:"push_id,omitempty"`
+	BatchFile            []byte                 `protobuf:"bytes,2,opt,name=batch_file,json=batchFile,proto3" json:"batch_file,omitempty"`
+	CodeDiff             string                 `protobuf:"bytes,3,opt,name=code_diff,json=codeDiff,proto3" json:"code_diff,omitempty"`
+	ChangeDescription    string                 `protobuf:"bytes,4,opt,name=change_description,json=changeDescription,proto3" json:"change_description,omitempty"`
+	EnvironmentVariables map[string]string      `protobuf:"bytes,5,rep,name=environment_variables,json=environmentVariables,proto3" json:"environment_variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *PushMessage) Reset() {
@@ -191,6 +192,13 @@ func (x *PushMessage) GetChangeDescription() string {
 		return x.ChangeDescription
 	}
 	return ""
+}
+
+func (x *PushMessage) GetEnvironmentVariables() map[string]string {
+	if x != nil {
+		return x.EnvironmentVariables
+	}
+	return nil
 }
 
 type PushResponse struct {
@@ -347,13 +355,17 @@ var File_ws_proto protoreflect.FileDescriptor
 
 const file_ws_proto_rawDesc = "" +
 	"\n" +
-	"\bws.proto\"\x91\x01\n" +
+	"\bws.proto\"\xb7\x02\n" +
 	"\vPushMessage\x12\x17\n" +
 	"\apush_id\x18\x01 \x01(\tR\x06pushId\x12\x1d\n" +
 	"\n" +
 	"batch_file\x18\x02 \x01(\fR\tbatchFile\x12\x1b\n" +
 	"\tcode_diff\x18\x03 \x01(\tR\bcodeDiff\x12-\n" +
-	"\x12change_description\x18\x04 \x01(\tR\x11changeDescription\"\xd2\x01\n" +
+	"\x12change_description\x18\x04 \x01(\tR\x11changeDescription\x12[\n" +
+	"\x15environment_variables\x18\x05 \x03(\v2&.PushMessage.EnvironmentVariablesEntryR\x14environmentVariables\x1aG\n" +
+	"\x19EnvironmentVariablesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xd2\x01\n" +
 	"\fPushResponse\x120\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x18.PushResponse.PushStatusR\x06status\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12\x17\n" +
@@ -389,24 +401,26 @@ func file_ws_proto_rawDescGZIP() []byte {
 }
 
 var file_ws_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_ws_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_ws_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_ws_proto_goTypes = []any{
 	(PushResponse_PushStatus)(0),      // 0: PushResponse.PushStatus
 	(WebsocketMessage_MessageType)(0), // 1: WebsocketMessage.MessageType
 	(*PushMessage)(nil),               // 2: PushMessage
 	(*PushResponse)(nil),              // 3: PushResponse
 	(*WebsocketMessage)(nil),          // 4: WebsocketMessage
+	nil,                               // 5: PushMessage.EnvironmentVariablesEntry
 }
 var file_ws_proto_depIdxs = []int32{
-	0, // 0: PushResponse.status:type_name -> PushResponse.PushStatus
-	1, // 1: WebsocketMessage.message_type:type_name -> WebsocketMessage.MessageType
-	2, // 2: WebsocketMessage.push_message:type_name -> PushMessage
-	3, // 3: WebsocketMessage.push_response:type_name -> PushResponse
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	5, // 0: PushMessage.environment_variables:type_name -> PushMessage.EnvironmentVariablesEntry
+	0, // 1: PushResponse.status:type_name -> PushResponse.PushStatus
+	1, // 2: WebsocketMessage.message_type:type_name -> WebsocketMessage.MessageType
+	2, // 3: WebsocketMessage.push_message:type_name -> PushMessage
+	3, // 4: WebsocketMessage.push_response:type_name -> PushResponse
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_ws_proto_init() }
@@ -424,7 +438,7 @@ func file_ws_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ws_proto_rawDesc), len(file_ws_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/ws.proto
+++ b/proto/ws.proto
@@ -7,6 +7,7 @@ message PushMessage {
     bytes batch_file = 2;
     string code_diff = 3;
     string change_description = 4;
+    map<string, string> environment_variables = 5;
 }
 message PushResponse {
     enum PushStatus {

--- a/proto/ws.proto
+++ b/proto/ws.proto
@@ -7,7 +7,11 @@ message PushMessage {
     bytes batch_file = 2;
     string code_diff = 3;
     string change_description = 4;
-    map<string, string> environment_variables = 5;
+    // Diff metadata fields (merged from DiffMetadata)
+    int32 files_changed = 5;
+    int32 additions = 6;
+    int32 deletions = 7;
+    map<string, string> environment_variables = 8;
 }
 message PushResponse {
     enum PushStatus {


### PR DESCRIPTION
Building on the work in: https://github.com/bifrostinc/code-sync-mcp/pull/9

* Sync protobuf with the latest in bifrost/
* Add a new `environment_variables` field to the PushMessage which will sync to the env file on the launcher. 
* Remove the fetching at start and simply do this sync when we receive a push message.
* Manage escaping and handling of different variables + update testing around it.